### PR TITLE
Fixes issue with files-attribute in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,9 +27,6 @@
     "build": "mkdir -p dist && browserify index.js -s vuvuzela -o dist/vuvuzela.js && npm run min",
     "min": "uglifyjs dist/vuvuzela.js -mc > dist/vuvuzela.min.js"
   },
-  "files": [
-    "dist"
-  ],
   "devDependencies": {
     "browserify": "~2.36.0",
     "chai": "^1.9.1",


### PR DESCRIPTION
Hi, 

using the 'files' attribute vuvuzela dependency can no longer be resolved for pouchdb, e.g., with webpack the following error will be shown: 

'Module not found: Error: Cannot resolve module 'vuvuzela' in /Users/daneis/Documents/diesunddas/wali/node_modules/pouchdb/lib' 

Vuvuzela package structure after npm install since version 1.0.2 (which introduced the files-attribute): 

> dist/
> package.json
> README.md

Vuvuzela package structure after npm install with versions < 1.0.2

> dist/
> test/
> package.json
> ...
> index.js

Issue seems to be that files-attribute limits the npm distributed package contents to the contents of the dist-folder. Since 'main'-attribute points to 'index.js' this file can no longer be resolved. 

Alternatively you could update the 'main'-attribute, but this seems discouraged by npm. 